### PR TITLE
Allow compilation.

### DIFF
--- a/src/query.lisp
+++ b/src/query.lisp
@@ -17,3 +17,16 @@
                           :statement statement
                           :properties properties)))
     q))
+
+(defmethod encode-neo4j-json-payload ((object cypher-query) (encode-type (eql :statement)) &key)
+  (declare (ignore encode-type))
+  (encode-cypher-query object))
+
+(defmethod encode-neo4j-json-payload (object (encode-type (eql :statements)) &key)
+  (declare (ignore encode-type))
+  (let ((table (make-hash-table :test 'equalp)))
+    (setf (gethash "statements" table)
+          (mapcar (lambda (statement)
+                    (structure-cypher-query statement))
+                  object))
+    (encode-neo4j-json-payload table :table)))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -42,18 +42,6 @@
                                      (list (cons "data" data)))
                                :object)))
 
-(defmethod encode-neo4j-json-payload ((object cypher-query) (encode-type (eql :statement)) &key)
-  (declare (ignore encode-type))
-  (encode-cypher-query object))
-
-(defmethod encode-neo4j-json-payload (object (encode-type (eql :statements)) &key)
-  (declare (ignore encode-type))
-  (let ((table (make-hash-table :test 'equalp)))
-    (setf (gethash "statements" table)
-          (mapcar (lambda (statement)
-                    (structure-cypher-query statement))
-                  object))
-    (encode-neo4j-json-payload table :table)))
 
 (defun decode-neo4j-json-output (json)
   (decode-json-from-string (babel:octets-to-string json)))


### PR DESCRIPTION
Shift the cypher-based functions to be defined after the cypher class
to break the circular dependency and allow Quicklisp loading.


This is because I need to use authentication with neo4j....