### PR TITLE
Changes to create new wrapper around new Neo4J HTTP API

### DIFF
--- a/cl-neo4j.asd
+++ b/cl-neo4j.asd
@@ -28,6 +28,7 @@
              (:file "query" :depends-on ("utilities"))
              (:file "requests" :depends-on ("conditions" "query"))
              (:file "restapi" :depends-on ("requests"))
+             (:file "transaction" :depends-on ("requests"))
              (:file "wrapper" :depends-on ("restapi"))))))
 
 (defsystem cl-neo4j.tests

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -1,6 +1,6 @@
 ;;; Conditions that low-level REST api throw in default unexpected situations.
 
-(in-package #:cl-neo4j)
+(in-package #:cl-neo4j.utils)
 
 (define-condition unknown-return-type-error (error)
   ((uri :accessor uri :initarg :uri)

--- a/src/globals.lisp
+++ b/src/globals.lisp
@@ -1,6 +1,7 @@
-(in-package #:cl-neo4j)
+(in-package #:cl-neo4j.utils)
 
 (defvar *neo4j-host* "localhost")
 (defvar *neo4j-port* 7474)
 (defvar *neo4j-user* "neo4j")
 (defvar *neo4j-pass* "neo4j")
+(defvar *neo4j-database* "data")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,57 +1,79 @@
 (in-package #:cl-user)
 
-(defpackage #:cl-neo4j
+(defpackage #:cl-neo4j.utils
   (:use #:cl
         #:alexandria
         #:anaphora
-	#:json
-	#:json-rpc
-	#:drakma)
-  (:export #:get-node
-           #:create-node
-           #:delete-node
-	   #:set-node-properties
-	   #:get-node-properties
-	   #:del-node-properties
-	   #:set-node-property
-	   #:get-node-property
-	   #:del-node-property
-           #:get-relationship
-           #:create-relationship
-	   #:set-relationship-properties
-	   #:get-relationship-properties
-	   #:del-relationship-properties
-	   #:set-relationship-property
-	   #:get-relationship-property
-	   #:del-relationship-property
-	   #:delete-relationship
-	   #:get-node-relationships
-           #:get-relationships-types
-	   #:create-index
-           #:delete-index
-           #:add-to-index
-           #:remove-from-index
-           #:lookup-index
-           #:query-index
-           #:traverse
-           #:get-path
-           #:get-paths
-           ;; Conditions
-           #:unknown-return-type-error
-           #:invalid-data-sent-error
-           #:node-not-found-error
-           #:property-not-found-error
-           #:unable-to-delete-node-error
-           #:relationship-not-found-error
-           #:index-not-found-error
-           #:index-entry-not-found-error
-           #:path-not-found-error
-	   ;; Vars
-	   #:*neo4j-host*
-	   #:*neo4j-port*
-	   #:*neo4j-user*
-	   #:*neo4j-pass*
-           ))
+        #:json
+        #:json-rpc
+        #:drakma)
+  (:export
+   ;; Conditions
+   #:unknown-return-type-error
+   #:invalid-data-sent-error
+   #:node-not-found-error
+   #:property-not-found-error
+   #:unable-to-delete-node-error
+   #:relationship-not-found-error
+   #:index-not-found-error
+   #:index-entry-not-found-error
+   #:path-not-found-error
+   ;; Macros
+   #:def-neo4j-fun
+   ;; query data structures
+   #:cypher-query
+   #:cypher-transaction
+   ;; Vars
+   #:*neo4j-host*
+   #:*neo4j-port*
+   #:*neo4j-user*
+   #:*neo4j-pass*
+   #:*neo4j-database*))
+
+(defpackage #:cl-neo4j.deprecated
+  (:use #:cl
+        #:alexandria
+        #:cl-neo4j.utils))
+
+(defpackage #:cl-neo4j
+  (:use
+   #:cl
+   #:cl-neo4j.utils
+   #:alexandria
+   #:anaphora
+   #:json
+   #:json-rpc
+   #:drakma)
+  (:export
+   #:get-node
+   #:create-node
+   #:delete-node
+   #:set-node-properties
+   #:get-node-properties
+   #:del-node-properties
+   #:set-node-property
+   #:get-node-property
+   #:del-node-property
+   #:get-relationship
+   #:create-relationship
+   #:set-relationship-properties
+   #:get-relationship-properties
+   #:del-relationship-properties
+   #:set-relationship-property
+   #:get-relationship-property
+   #:del-relationship-property
+   #:delete-relationship
+   #:get-node-relationships
+   #:get-relationships-types
+   #:create-index
+   #:delete-index
+   #:add-to-index
+   #:remove-from-index
+   #:lookup-index
+   #:query-index
+   #:traverse
+   #:get-path
+   #:get-paths))
 
 (defpackage #:cl-neo4j-wrapper
   (:use #:cl
@@ -91,3 +113,16 @@
            ;: Vars
            #:*default-node-constructor*
            #:*default-relationship-constructor*))
+
+(defpackage #:cl-neo4j.transaction
+  (:use #:cl
+        #:alexandria
+        #:anaphora)
+  (:export
+   ;; transaction
+   #:tx-create-node
+   #:tx-get-node
+   #:tx-delete-node
+   #:tx-relationship-create
+   #:tx-relationship-get-by-id
+   #:tx-relationship-delete))

--- a/src/query.lisp
+++ b/src/query.lisp
@@ -1,4 +1,7 @@
-(in-package #:cl-neo4j)
+(in-package #:cl-neo4j.utils)
+
+(defclass cypher-transaction ()
+  ((statements :initarg :statements :accessor statements :initform '())))
 
 (defclass cypher-query ()
   ((statement :accessor statement :initform "" :initarg :statement)

--- a/src/restapi.lisp
+++ b/src/restapi.lisp
@@ -2,56 +2,56 @@
 
 (in-package #:cl-neo4j)
 
-(def-neo4j-fun get-node (node-id)
+(cl-neo4j.utils:def-neo4j-fun get-node (node-id)
   :get
   (:uri-spec (if node-id
                  (format nil "node/~A" node-id)
                  ""))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'node-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun create-node (properties)
+(cl-neo4j.utils:def-neo4j-fun create-node (properties)
   :post
   (:uri-spec (format nil "node"))
   (:encode properties :string)
   (:status-handlers
-   (201 (decode-neo4j-json-output body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))))
+   (201 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (400 (error 'invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))))
 
-(def-neo4j-fun delete-node (node-id)
+(cl-neo4j.utils:def-neo4j-fun delete-node (node-id)
   :delete
   (:uri-spec (format nil "node/~A" node-id))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'node-not-found-error :uri uri))
-   (409 (error 'unable-to-delete-node-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'node-not-found-error :uri cl-neo4j.utils::uri))
+   (409 (error 'unable-to-delete-node-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun set-node-properties (node-id properties)
+(cl-neo4j.utils:def-neo4j-fun set-node-properties (node-id properties)
   :put
   (:encode properties :string)
   (:uri-spec (format nil "node/~A/properties" node-id))
   (:status-handlers
-   (204 (values t body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))
-   (404 (error 'node-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (400 (error 'invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))
+   (404 (error 'node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-node-properties (node-id)
+(cl-neo4j.utils:def-neo4j-fun get-node-properties (node-id)
   :get
   (:uri-spec (format nil "node/~A/properties" node-id))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
    (204 nil)
-   (404 (error 'node-not-found-error :uri uri))))
+   (404 (error 'node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun del-node-properties (node-id)
+(cl-neo4j.utils:def-neo4j-fun del-node-properties (node-id)
   :delete
   (:uri-spec (format nil "node/~A/properties" node-id))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'node-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun set-node-property (node-id property value)
+(cl-neo4j.utils:def-neo4j-fun set-node-property (node-id property value)
   :put
   (:uri-spec (format nil "node/~A/properties/~A" node-id
                      (if (symbolp property)
@@ -59,79 +59,79 @@
                          property)))
   (:encode value :string)
   (:status-handlers
-   (204 (values t body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))))
+   (204 (values t cl-neo4j.utils::body))
+   (400 (error 'invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))))
 
-(def-neo4j-fun get-node-property (node-id property)
+(cl-neo4j.utils:def-neo4j-fun get-node-property (node-id property)
   :get
   (:uri-spec (format nil "node/~A/properties/~A" node-id
                      (if (symbolp property)
                          (string-downcase (symbol-name property))
                          property)))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))
-   (404 (error 'property-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (400 (error 'invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))
+   (404 (error 'property-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun del-node-property (node-id property)
+(cl-neo4j.utils:def-neo4j-fun del-node-property (node-id property)
   :delete
   (:uri-spec (format nil "node/~A/properties/~A" node-id
                      (if (symbolp property)
                          (string-downcase (symbol-name property))
                          property)))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))
-   (409 (error 'cl-neo4j.utils:unable-to-delete-node-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri cl-neo4j.utils::uri))
+   (409 (error 'cl-neo4j.utils:unable-to-delete-node-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-relationship (relationship-id)
+(cl-neo4j.utils:def-neo4j-fun get-relationship (relationship-id)
   :get
   (:uri-spec (format nil "relationship/~A" relationship-id))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun create-relationship (node-id to-node-id relationship-type properties)
+(cl-neo4j.utils:def-neo4j-fun create-relationship (node-id to-node-id relationship-type properties)
   :post
   (:uri-spec (format nil "node/~A/relationships" node-id))
   (:encode (list to-node-id relationship-type properties) :relationship)
   (:status-handlers
-   (201 (decode-neo4j-json-output body))
-   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
-   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
+   (201 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun delete-relationship (relationship-id)
+(cl-neo4j.utils:def-neo4j-fun delete-relationship (relationship-id)
   :delete
   (:uri-spec (format nil "relationship/~A" relationship-id))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun set-relationship-properties (relationship-id properties)
+(cl-neo4j.utils:def-neo4j-fun set-relationship-properties (relationship-id properties)
   :put
   (:uri-spec (format nil "relationship/~A/properties" relationship-id))
   (:encode properties :string)
   (:status-handlers
-   (204 (values t body))
-   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-relationship-properties (relationship-id)
+(cl-neo4j.utils:def-neo4j-fun get-relationship-properties (relationship-id)
   :get
   (:uri-spec (format nil "relationship/~A/properties" relationship-id))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
    (204 nil)
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun del-relationship-properties (relationship-id)
+(cl-neo4j.utils:def-neo4j-fun del-relationship-properties (relationship-id)
   :delete
   (:uri-spec (format nil "relationship/~A/properties" relationship-id))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun set-relationship-property (relationship-id property value)
+(cl-neo4j.utils:def-neo4j-fun set-relationship-property (relationship-id property value)
   :put
   (:uri-spec (format nil "relationship/~A/properties/~A"
                      relationship-id
@@ -140,11 +140,11 @@
                          property)))
   (:encode value :string)
   (:status-handlers
-   (204 (values t body))
-   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-relationship-property (relationship-id property)
+(cl-neo4j.utils:def-neo4j-fun get-relationship-property (relationship-id property)
   :get
   (:uri-spec (format nil "relationship/~A/properties/~A"
                      relationship-id
@@ -152,11 +152,11 @@
                          (string-downcase (symbol-name property))
                          property)))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
-   (404 (error 'cl-neo4j.utils:property-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri cl-neo4j.utils::uri :json json))
+   (404 (error 'cl-neo4j.utils:property-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun del-relationship-property (relationship-id property)
+(cl-neo4j.utils:def-neo4j-fun del-relationship-property (relationship-id property)
   :delete
   (:uri-spec (format nil "relationship/~A/properties/~A"
                      relationship-id
@@ -164,10 +164,10 @@
                          (string-downcase (symbol-name property))
                          property)))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-node-relationships (node-id direction types)
+(cl-neo4j.utils:def-neo4j-fun get-node-relationships (node-id direction types)
   :get
   (:uri-spec (format nil "node/~A/relationships/~A/~{~A~^\\&~}"
                      node-id
@@ -177,44 +177,44 @@
                            (t direction))
                      types))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-relationships-types ()
+(cl-neo4j.utils:def-neo4j-fun get-relationships-types ()
   :get
   (:uri-spec "relationship/types")
   (:status-handlers
-   (200 (decode-neo4j-json-output body))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))))
 
-(def-neo4j-fun cypher-query (statements)
+(cl-neo4j.utils:def-neo4j-fun cypher-query (statements)
   :post
   (:uri-spec "transaction/commit")
   (:encode statements :statements)
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun create-index ((type :node) name config)
+(cl-neo4j.utils:def-neo4j-fun create-index ((type :node) name config)
   :post
   (:uri-spec (format nil "index/~A" (string-downcase (symbol-name type))))
   (:encode (cons (cons :name name) config) :string)
   (:status-handlers
-   (201 (decode-neo4j-json-output body))))
+   (201 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))))
 
-(def-neo4j-fun delete-index ((type :node) name)
+(cl-neo4j.utils:def-neo4j-fun delete-index ((type :node) name)
   :delete
   (:uri-spec (format nil "index/~A/~A" (string-downcase (symbol-name type)) name))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'cl-neo4j.utils:index-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:index-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun list-indexes ((type :node))
+(cl-neo4j.utils:def-neo4j-fun list-indexes ((type :node))
   :get
   (:uri-spec (format nil "index/~A" (string-downcase (symbol-name type))))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))))
 
-(def-neo4j-fun add-to-index ((type :node) name key value object-id)
+(cl-neo4j.utils:def-neo4j-fun add-to-index ((type :node) name key value object-id)
   :post
   (:uri-spec (format nil "index/~A/~A" (string-downcase (symbol-name type))
                      name))
@@ -226,33 +226,33 @@
                  (list (cons :value value)))
            :object)
   (:status-handlers
-   (201 (decode-neo4j-json-output body))))
+   (201 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))))
 
-(def-neo4j-fun remove-from-index ((type :node) name key value object-id)
+(cl-neo4j.utils:def-neo4j-fun remove-from-index ((type :node) name key value object-id)
   :delete
   (:uri-spec (format nil "index/~A/~A/~@[~A/~]~@[~A/~]~A" (string-downcase (symbol-name type))
-                     name key (urlencode value) object-id))
+                     name key (cl-neo4j.utils::urlencode value) object-id))
   (:status-handlers
-   (204 (values t body))
-   (404 (error 'index-entry-not-found-error :uri uri))))
+   (204 (values t cl-neo4j.utils::body))
+   (404 (error 'index-entry-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun lookup-index ((type :node) name key value)
+(cl-neo4j.utils:def-neo4j-fun lookup-index ((type :node) name key value)
   :get
   (:uri-spec (format nil "index/~A/~A/~A/~A" (string-downcase (symbol-name type))
-                     name key (urlencode value)))
+                     name key (cl-neo4j.utils::urlencode value)))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'index-entry-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'index-entry-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun query-index ((type :node) name query)
+(cl-neo4j.utils:def-neo4j-fun query-index ((type :node) name query)
   :get
   (:uri-spec (format nil "index/~A/~A/?query=~A" (string-downcase (symbol-name type))
-                     name (urlencode query)))
+                     name (cl-neo4j.utils::urlencode query)))
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'index-entry-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'index-entry-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun traverse (node-id (return-type :node) (max-depth 1) (order :depth-first)
+(cl-neo4j.utils:def-neo4j-fun traverse (node-id (return-type :node) (max-depth 1) (order :depth-first)
                          uniqueness relationships prune-evaluator return-filter)
   :post
   (:uri-spec (format nil "node/~A/traverse/~A" node-id (string-downcase (symbol-name return-type))))
@@ -268,10 +268,10 @@
             (cons "max_depth" max-depth))
            :string)
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-path (node-id to-node-id relationships (max-depth 3) (algorithm :shortest-path))
+(cl-neo4j.utils:def-neo4j-fun get-path (node-id to-node-id relationships (max-depth 3) (algorithm :shortest-path))
   :post
   (:uri-spec (format nil "node/~A/path" node-id))
   (:encode (list (list (cons "to" to-node-id) :node-url)
@@ -284,10 +284,10 @@
                                            (:dijkstra "dijkstra")))))
            :object)
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (404 (error 'cl-neo4j.utils:path-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (404 (error 'cl-neo4j.utils:path-not-found-error :uri cl-neo4j.utils::uri))))
 
-(def-neo4j-fun get-paths (node-id to-node-id relationships (max-depth 3) (algorithm :shortest-path))
+(cl-neo4j.utils:def-neo4j-fun get-paths (node-id to-node-id relationships (max-depth 3) (algorithm :shortest-path))
   :post
   (:uri-spec (format nil "node/~A/paths" node-id))
   (:encode (list (list (cons "to" to-node-id) :node-url)
@@ -300,5 +300,5 @@
                                            (:dijkstra "dijkstra")))))
            :object)
   (:status-handlers
-   (200 (decode-neo4j-json-output body))
-   (204 (error 'cl-neo4j.utils:path-not-found-error :uri uri))))
+   (200 (cl-neo4j.utils::decode-neo4j-json-output cl-neo4j.utils::body))
+   (204 (error 'cl-neo4j.utils:path-not-found-error :uri cl-neo4j.utils::uri))))

--- a/src/restapi.lisp
+++ b/src/restapi.lisp
@@ -81,15 +81,15 @@
                          property)))
   (:status-handlers
    (204 (values t body))
-   (404 (error 'node-not-found-error :uri uri))
-   (409 (error 'unable-to-delete-node-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))
+   (409 (error 'cl-neo4j.utils:unable-to-delete-node-error :uri uri))))
 
 (def-neo4j-fun get-relationship (relationship-id)
   :get
   (:uri-spec (format nil "relationship/~A" relationship-id))
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun create-relationship (node-id to-node-id relationship-type properties)
   :post
@@ -97,15 +97,15 @@
   (:encode (list to-node-id relationship-type properties) :relationship)
   (:status-handlers
    (201 (decode-neo4j-json-output body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))
-   (404 (error 'node-not-found-error :uri uri))))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
 
 (def-neo4j-fun delete-relationship (relationship-id)
   :delete
   (:uri-spec (format nil "relationship/~A" relationship-id))
   (:status-handlers
    (204 (values t body))
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun set-relationship-properties (relationship-id properties)
   :put
@@ -113,8 +113,8 @@
   (:encode properties :string)
   (:status-handlers
    (204 (values t body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun get-relationship-properties (relationship-id)
   :get
@@ -122,14 +122,14 @@
   (:status-handlers
    (200 (decode-neo4j-json-output body))
    (204 nil)
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun del-relationship-properties (relationship-id)
   :delete
   (:uri-spec (format nil "relationship/~A/properties" relationship-id))
   (:status-handlers
    (204 (values t body))
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun set-relationship-property (relationship-id property value)
   :put
@@ -141,8 +141,8 @@
   (:encode value :string)
   (:status-handlers
    (204 (values t body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun get-relationship-property (relationship-id property)
   :get
@@ -153,8 +153,8 @@
                          property)))
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (400 (error 'invalid-data-sent-error :uri uri :json json))
-   (404 (error 'property-not-found-error :uri uri))))
+   (400 (error 'cl-neo4j.utils:invalid-data-sent-error :uri uri :json json))
+   (404 (error 'cl-neo4j.utils:property-not-found-error :uri uri))))
 
 (def-neo4j-fun del-relationship-property (relationship-id property)
   :delete
@@ -165,7 +165,7 @@
                          property)))
   (:status-handlers
    (204 (values t body))
-   (404 (error 'relationship-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:relationship-not-found-error :uri uri))))
 
 (def-neo4j-fun get-node-relationships (node-id direction types)
   :get
@@ -178,7 +178,7 @@
                      types))
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (404 (error 'node-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
 
 (def-neo4j-fun get-relationships-types ()
   :get
@@ -192,7 +192,7 @@
   (:encode statements :statements)
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (404 (error 'node-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
 
 (def-neo4j-fun create-index ((type :node) name config)
   :post
@@ -206,7 +206,7 @@
   (:uri-spec (format nil "index/~A/~A" (string-downcase (symbol-name type)) name))
   (:status-handlers
    (204 (values t body))
-   (404 (error 'index-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:index-not-found-error :uri uri))))
 
 (def-neo4j-fun list-indexes ((type :node))
   :get
@@ -269,7 +269,7 @@
            :string)
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (404 (error 'node-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:node-not-found-error :uri uri))))
 
 (def-neo4j-fun get-path (node-id to-node-id relationships (max-depth 3) (algorithm :shortest-path))
   :post
@@ -285,7 +285,7 @@
            :object)
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (404 (error 'path-not-found-error :uri uri))))
+   (404 (error 'cl-neo4j.utils:path-not-found-error :uri uri))))
 
 (def-neo4j-fun get-paths (node-id to-node-id relationships (max-depth 3) (algorithm :shortest-path))
   :post
@@ -301,4 +301,4 @@
            :object)
   (:status-handlers
    (200 (decode-neo4j-json-output body))
-   (204 (error 'path-not-found-error :uri uri))))
+   (204 (error 'cl-neo4j.utils:path-not-found-error :uri uri))))

--- a/src/transaction.lisp
+++ b/src/transaction.lisp
@@ -1,0 +1,60 @@
+(in-package #:cl-neo4j.transaction)
+
+;; {"statements": [{"statement":<cypher-query>, "parameters": {}}]}
+(defun make-cypher-transaction (&rest statements)
+  (make-instance 'cl-neo4j.utils:cypher-transaction :statements statements))
+
+(defun make-cypher-query (statement &optional parameters)
+  (let ((res (make-instance 'cl-neo4j.utils:cypher-query :statement statement)))
+    (when parameters
+      (setf (properties res) parameters))
+    res))
+
+(defun create-node-query (node-name node-type node-properties)
+  (format nil "CREATE (~A:~A {~{~A:\"~A\"~^,~}})"
+          node-name
+          node-type
+          node-properties))
+
+(defun get-node-by-id-query (node-id)
+  (format nil "MATCH (x) WHERE ID(x) = ~a RETURN x;" node-id))
+
+(defun delete-node-query (node-id)
+  (format nil "MATCH (x) WHERE ID(x) = ~a DETACH DELETE x;" node-id))
+
+(defun create-relationship-query (src-node src-node-type src-node-props dst-node dst-node-type dst-node-props relationship-type properties)
+  (format nil "MATCH (x:~a) WHERE x0MATCH (y:~a {~{~a:\"~a\"~^,~}}) MERGE (~a)-[~a {~{~a:\"~a\"~^,~}}]->(~a);"
+          src-node-type
+          src-node-props
+          dst-node
+          dst-node-type
+          dst-node-props
+          relationship-type
+          properties))
+
+(cl-neo4j.utils:def-neo4j-fun tx-create-node (node-id node-type node-properties)
+  :post
+  (:uri-spec (format nil "tx/commit"))
+  (:encode (make-cypher-transaction
+            (make-cypher-query (create-node-query node-id node-type node-properties))) :string)
+  (:status-handlers
+   (200 (cl-neo4j::decode-neo4j-json-output cl-neo4j::body))
+   (404 (error 'node-not-found-error :uri cl-neo4j::uri))))
+
+(cl-neo4j.utils:def-neo4j-fun tx-get-node (node-id)
+  :post
+  (:uri-spec (format nil "tx/commit"))
+  (:encode (make-cypher-transaction
+            (make-cypher-query (get-node-by-id-query node-id))) :string)
+  (:status-handlers
+   (200 (cl-neo4j::decode-neo4j-json-output cl-neo4j::body))
+   (404 (error 'node-not-found-error :uri cl-neo4j::uri))))
+
+(cl-neo4j.utils:def-neo4j-fun tx-delete-node (node-id)
+  :post
+  (:uri-spec (format nil "tx/commit"))
+  (:encode (make-cypher-transaction
+            (make-cypher-query (delete-node-query node-id))) :string)
+  (:status-handlers
+   (200 (cl-neo4j::decode-neo4j-json-output cl-neo4j::body))
+   (404 (error 'node-not-found-error :uri cl-neo4j::uri))))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -1,4 +1,4 @@
-(in-package #:cl-neo4j)
+(in-package #:cl-neo4j.utils)
 
 (defun format-neo4j-query (host port resource &key (db-postfix "db/data/"))
   (format nil "http://~A:~A/~A~A" host port db-postfix resource))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -10,6 +10,7 @@
 
 (defmethod encode-neo4j-json-payload (object (encode-type (eql :node-url)) &key (host *neo4j-host*) (port *neo4j-port*))
   (declare (ignore encode-type))
+  (format t "encoding node url~%")
   (format-neo4j-query host port (format nil "node/~A" object)))
 
 (defmethod encode-neo4j-json-payload (object (encode-type (eql :node-url-single)) &key (host *neo4j-host*) (port *neo4j-port*))
@@ -18,6 +19,7 @@
 
 (defmethod encode-neo4j-json-payload (object (encode-type (eql :relationship-url)) &key (host *neo4j-host*) (port *neo4j-port*))
   (declare (ignore encode-type))
+  (format t "encoding relationship url~%")
   (format-neo4j-query host port (format nil "relationship/~A" object)))
 
 (defmethod encode-neo4j-json-payload (object (encode-type (eql :relationship-url-single)) &key (host *neo4j-host*) (port *neo4j-port*))

--- a/test/main.lisp
+++ b/test/main.lisp
@@ -4,3 +4,4 @@
   (run! 'cl-neo4j))
 
 (def-suite cl-neo4j)
+(def-suite cl-neo4j-transaction)

--- a/test/restapi.lisp
+++ b/test/restapi.lisp
@@ -10,7 +10,7 @@
     (is (equal node-id
                (get-id-from-data (cl-neo4j:get-node :node-id node-id))))
     (is (cl-neo4j:delete-node :node-id node-id))
-    (signals (cl-neo4j:node-not-found-error)
+    (signals (cl-neo4j.utils:node-not-found-error)
       (cl-neo4j:delete-node :node-id node-id))))
 
 (test get-node
@@ -18,7 +18,7 @@
     (is (equal (get-id-from-data (cl-neo4j:get-node :node-id a))
                a))
     (cl-neo4j:delete-node :node-id b)
-    (signals (cl-neo4j:node-not-found-error)
+    (signals (cl-neo4j.utils:node-not-found-error)
       (cl-neo4j:get-node :node-id b))))
 
 (test node-properties
@@ -31,7 +31,7 @@
                "test"))
     (is (cl-neo4j:del-node-properties :node-id a))
     (is (null (cl-neo4j:get-node-properties :node-id a)))
-    (signals (cl-neo4j:property-not-found-error)
+    (signals (cl-neo4j.utils:property-not-found-error)
       (cl-neo4j:get-node-property :node-id a :property :test))
     (is (cl-neo4j:set-node-property :node-id a
                                     :property :test
@@ -50,7 +50,7 @@
       (is (cdr (assoc :type (cl-neo4j:get-relationship :relationship-id r)))
           "test")
       (is (cl-neo4j:delete-relationship :relationship-id r))
-      (signals (cl-neo4j:relationship-not-found-error)
+      (signals (cl-neo4j.utils:relationship-not-found-error)
         (cl-neo4j:get-relationship :relationship-id r)))))
 
 (test get-relationship
@@ -59,7 +59,7 @@
                                   :relationship-id ab))
                ab))
     (cl-neo4j:delete-relationship :relationship-id ba)
-    (signals (cl-neo4j:relationship-not-found-error)
+    (signals (cl-neo4j.utils:relationship-not-found-error)
       (cl-neo4j:get-relationship :relationship-id ba))))
 
 (test relationship-properties
@@ -72,7 +72,7 @@
                "test"))
     (is (cl-neo4j:del-relationship-properties :relationship-id ab))
     (is (null (cl-neo4j:get-relationship-properties :relationship-id ab)))
-    (signals (cl-neo4j:property-not-found-error)
+    (signals (cl-neo4j.utils:property-not-found-error)
       (cl-neo4j:get-relationship-property :relationship-id ab :property :test))
     (is (cl-neo4j:set-relationship-property :relationship-id ab
                                     :property :test
@@ -103,7 +103,7 @@
   (with-test-nodes (a b) ()
     (is (cl-neo4j:create-index :name "i1"))
     (is (cl-neo4j:delete-index :name "i1"))
-    (signals (cl-neo4j:index-not-found-error)
+    (signals (cl-neo4j.utils:index-not-found-error)
       (cl-neo4j:delete-index :name "i1"))
     (is (cl-neo4j:create-index :name "i1"))
     (is (cl-neo4j:add-to-index :name "i1"


### PR DESCRIPTION
# Context

As of Neo4J 4.x, the Neo4J HTTP API was updated to support transactions and the old REST API was deprecated. However, existing customers as well as users who may want to leverage services as Neo4J Aura may still need to leverage the old REST base API based on nodes, relationships, etc. Therefore, the set of changes here are a series of refactorings I propose as part of a new effort to support the transaction based HTTP API from within cl-neo4j. 

Specifically, these changes include:

- creating new packages to separate utility classes, errors, etc.
for further use in transaction package
- creation of transaction package
- added methods for adding nodes in Neo4J 4.X or later using new HTTP API with transactions

Remaining things TODO:

- add unit tests for new api
- fix unit test failures
- documentation

There is still some work to get done before this is fully polished, but given the set of changes made involved some significant refactoring, I thought I'd create a pull-request to get some feedback.